### PR TITLE
Fix FP8 KV-cache decode/prefill kBlockN divergence causing logprob mismatch (sgl-project/sglang#25790)

### DIFF
--- a/hopper/tile_size.h
+++ b/hopper/tile_size.h
@@ -56,11 +56,13 @@ constexpr std::tuple<int, int, bool, bool> tile_size_fwd_sm90(
         } else if (headdim <= 96) {
             return {192, 128, true, true};
         } else if (headdim <= 128) {
-            if (use_one_mma_wg) {
-                return {64, 96, true, true};
-            } else {
-                return {128, paged_kv_non_TMA ? 160 : (v_colmajor || (softcap && is_local) ? 192 : 224), true, true};
-            }
+            // Decode and prefill share the same kBlockN so the online-softmax
+            // reduction over K uses the same tile boundaries in both paths,
+            // removing the systematic FP8 KV-cache decode/prefill logprob
+            // mismatch (sgl-project/sglang#25790). Decode keeps a smaller
+            // kBlockM=64 for latency; only kBlockN needs to match prefill's.
+            int const kBlockN = paged_kv_non_TMA ? 160 : (v_colmajor || (softcap && is_local) ? 192 : 224);
+            return {use_one_mma_wg ? 64 : 128, kBlockN, true, true};
         } else if (headdim <= 192) {
             return {128, (paged_kv_non_TMA || softcap) && is_local ? 128 : 160, true, true};
         } else {


### PR DESCRIPTION
## Summary

Fixes the decode-vs-prefill logprob mismatch reported in [sgl-project/sglang#25790](https://github.com/sgl-project/sglang/issues/25790) when using `--kv-cache-dtype fp8_e4m3`. The bug lives in this repo — sglang currently pins commit [`f89bc2306632d1ec5f97b014dded4254f5b4a907`](https://github.com/sgl-project/sgl-attn/commit/f89bc2306632d1ec5f97b014dded4254f5b4a907) via [`python/sglang/kernels/aot/CMakeLists.txt#L85`](https://github.com/sgl-project/sglang/blob/main/python/sglang/kernels/aot/CMakeLists.txt#L85).

## Problem

With FP8 KV cache, logprobs computed by decoding one token at a time diverge systematically from logprobs computed by a single prefill pass over the same completed sequence, starting at a fixed absolute position. Independently reproduced by multiple people on H100/H200 with Qwen3-8B/14B-FP8 and MiniMax-2.5; bf16 KV cache is bitwise identical between the two paths.

Re-verified on this repo's currently-pinned commit (`f89bc23`) via `sgl_kernel.flash_attn.flash_attn_with_kvcache`, comparing a 1-row (decode) vs. an L-row (prefill) causal query against the *same* FP8 KV buffer, sweeping `kv_len` from 88 to 256:

| dtype | first mismatching `kv_len` | mismatched lengths (of 31 tested) | max abs diff |
|---|---|---|---|
| fp8_e4m3 | **97** | 19 | ~3.9e-3 – 1.07e-2 |
| bf16 | — | 0 (bitwise identical) | 0 |

## Root cause

[`hopper/heuristics.h#L10-15`](https://github.com/sgl-project/sgl-attn/blob/f89bc2306632d1ec5f97b014dded4254f5b4a907/hopper/heuristics.h#L10-L15) selects a different code path for decode (effective query length ≤ 64) vs. prefill:

```cpp
inline bool use_one_mma_wg(Flash_fwd_params const& params) {
    // Use 1 MMA warp group instead of 2-3 when effective Q length is small.
    // This gives better perf for decode / small-batch scenarios on Hopper.
    return params.arch >= 90 && (params.d == 128 || params.d == 64) &&
        params.seqlen_q * (params.h / params.h_k) <= 64;
};
```

For FP8 (`element_size == 1`) with `headdim <= 128`, this selects a different KV tile width (`kBlockN`) for the two paths ([`hopper/tile_size.h#L58-63`](https://github.com/sgl-project/sgl-attn/blob/f89bc2306632d1ec5f97b014dded4254f5b4a907/hopper/tile_size.h#L58-L63)):

```cpp
} else if (headdim <= 128) {
    if (use_one_mma_wg) {
        return {64, 96, true, true};   // decode: kBlockN = 96
    } else {
        return {128, paged_kv_non_TMA ? 160 : (v_colmajor || (softcap && is_local) ? 192 : 224), true, true};  // prefill: kBlockN = 160/192/224
    }
} else if (headdim <= 192) {
```

Both paths reach the same kernel through the same call sites ([`hopper/flash_api.cpp#L402`](https://github.com/sgl-project/sgl-attn/blob/f89bc2306632d1ec5f97b014dded4254f5b4a907/hopper/flash_api.cpp#L402), [`#L420`](https://github.com/sgl-project/sgl-attn/blob/f89bc2306632d1ec5f97b014dded4254f5b4a907/hopper/flash_api.cpp#L420), [`#L434`](https://github.com/sgl-project/sgl-attn/blob/f89bc2306632d1ec5f97b014dded4254f5b4a907/hopper/flash_api.cpp#L434), [`#L644`](https://github.com/sgl-project/sgl-attn/blob/f89bc2306632d1ec5f97b014dded4254f5b4a907/hopper/flash_api.cpp#L644); [`hopper/flash_fwd_launch_template.h#L41`](https://github.com/sgl-project/sgl-attn/blob/f89bc2306632d1ec5f97b014dded4254f5b4a907/hopper/flash_fwd_launch_template.h#L41), [`#L221-225`](https://github.com/sgl-project/sgl-attn/blob/f89bc2306632d1ec5f97b014dded4254f5b4a907/hopper/flash_fwd_launch_template.h#L221-L225)), but with a different KV tile width.

Online softmax reduces along K in `kBlockN`-sized chunks, so a different tile width means a different reduction/compensation order. In bf16 this reordering is numerically harmless (float accumulation is exact enough that reordering doesn't produce a visible difference). In FP8, the per-tile dequantize/requantize step is lossy, and the resulting error compounds differently depending on where the tile boundaries fall — the two paths only start to disagree once the KV length exceeds the smaller of the two tile widths, i.e. `kv_len = kBlockN_decode + 1 = 97`, which matches the measurement above exactly.

bf16 has the same `use_one_mma_wg`-driven `kBlockN` split ([`hopper/tile_size.h#L22-34`](https://github.com/sgl-project/sgl-attn/blob/f89bc2306632d1ec5f97b014dded4254f5b4a907/hopper/tile_size.h#L22-L34)) but doesn't show the effect, because there's no lossy quantization step for the divergence to attach to.

## Fix

Make decode and prefill for FP8 `headdim <= 128` share the same `kBlockN`, keeping decode's smaller `kBlockM = 64` for latency (the online-softmax compensation chain iterates over K-tiles, i.e. `kBlockN`, not over Q-rows-per-block, so `kBlockM` doesn't need to match):

```diff
 } else if (headdim <= 128) {
-    if (use_one_mma_wg) {
-        return {64, 96, true, true};
-    } else {
-        return {128, paged_kv_non_TMA ? 160 : (v_colmajor || (softcap && is_local) ? 192 : 224), true, true};
-    }
+    // Decode and prefill share the same kBlockN so the online-softmax
+    // reduction over K uses the same tile boundaries in both paths,
+    // removing the systematic FP8 KV-cache decode/prefill logprob
+    // mismatch (sgl-project/sglang#25790). Decode keeps a smaller
+    // kBlockM=64 for latency; only kBlockN needs to match prefill's.
+    int const kBlockN = paged_kv_non_TMA ? 160 : (v_colmajor || (softcap && is_local) ? 192 : 224);
+    return {use_one_mma_wg ? 64 : 128, kBlockN, true, true};
 } else if (headdim <= 192) {
```

(`int const`, not `int constexpr` — this function is also called with runtime arguments elsewhere in the codebase, e.g. from `flash_api.cpp` with `params.d_rounded` etc., so a `constexpr` local here would fail to compile; `const` matches the style already used elsewhere in this file, e.g. `bool const use_blockN_128 = ...` a few lines up.)

## Testing

Same kernel-level comparison as above, before/after:

| | first mismatching `kv_len` | mismatched lengths (of 31) | max abs diff |
|---|---|---|---|
| before | 97 | 19 | ~1.07e-2 |
| after | — | 0 | 0 (bitwise identical) |
| bf16 (unchanged, for reference) | — | 0 | 0 |

Repro: `flash_attn_with_kvcache`, 1-row vs. L-row causal query over the same FP8 KV buffer, sweeping `kv_len` 88–256.

I also mechanically checked (outside this PR, via a standalone enumeration over `headdim ∈ {32,64,96,128,160,192,224,256}` and all combinations of `is_local` / `paged_kv_non_TMA`) that this change leaves every prefill (`use_one_mma_wg = false`) configuration bit-for-bit identical to before the change, and only alters decode's `kBlockN` for the `headdim` bucket this issue is about — happy to share that script if useful for review.

## Performance

Decode's `kBlockN` grows from 96 to 160 (default, non-paged-non-TMA case), which *reduces* the number of KV-tile reloads per decode step. A local build of an equivalent change showed decode throughput improve rather than regress, but this should be re-benchmarked on top of this PR before merging.

## Notes for reviewers

- This PR targets the `sgl-kernel` branch, not `main` — `main` has since moved to a different SM90 rewrite that already removes `use_one_mma_wg` entirely (commit `fc8cbad6` onward), but that's a different architecture line that sglang doesn't build against yet. `sgl-kernel`'s current tip is exactly the commit sglang pins (`f89bc23`), so this is a minimal, targeted fix on the branch that's actually in production use.

- **Alternative considered: re-pinning the AOT build to `main` instead of touching kernel code.** Since `main` already removed `use_one_mma_wg`, one could argue for just bumping sglang's pinned commit to `main` and getting the fix "for free". We deliberately did not take that route here: (1) `main` has moved to a different SM100 / CuTe-DSL / FA4 kernel line that sglang does not build against yet, so Hopper (SM90) compatibility with sglang's AOT build is unverified; (2) re-pinning pulls in every change since `f89bc23` (including the varlen num_splits OOM fix in #46), making regressions much harder to bisect; (3) it deserves its own upstream-sync PR with its own validation. This PR keeps the change minimal on the exact commit that's in production use.

- Once this merges, `sgl-project/sglang`'s [`python/sglang/kernels/aot/CMakeLists.txt#L85`](https://github.com/sgl-project/sglang/blob/main/python/sglang/kernels/aot/CMakeLists.txt#L85) will need its pinned URL bumped to the new commit. I'll follow up with that (trivial) PR against `sgl-project/sglang` once this lands, unless a maintainer prefers to fold it in here.

- Related: sgl-project/sglang#25790 (original report, still open), sgl-project/sglang#35938 (adds a warning when deterministic inference is combined with a quantized KV cache — useful, but doesn't fix the underlying mismatch).
