### PR TITLE
Fix SM8x attention shared-memory reuse and local KV bounds

### DIFF
--- a/hopper/block.h
+++ b/hopper/block.h
@@ -6,7 +6,7 @@
 
 namespace flash {
 
-template <class SeqlenInfo_t, int kBlockM, int kBlockN, bool Is_causal, bool Is_local, bool PackGQA=false, bool Split=false>
+template <class SeqlenInfo_t, int kBlockM, int kBlockN, bool Is_causal, bool Is_local, bool PackGQA=false, bool Split=false, bool UseLocalKVOffset=true>
 struct BlockMN {
 
     static
@@ -21,6 +21,7 @@ struct BlockMN {
         int seqlen_k = seqlen_info.seqlen_k;
         int const seqlen_q = seqlen_info.seqlen_q;
         int n_offset = 0;
+        int n_block_min = 0;
 
         // If local, calculate n_offset and update seqlen_k
         if constexpr (Is_local) {
@@ -31,10 +32,13 @@ struct BlockMN {
             if (attention_chunk_divmod.divisor > 0) {
                 n_idx_left = std::max(n_idx_left, flash::round_down(attention_chunk_divmod, n_idx));
             }
-            // unlike previously, we don't divide by kBlockN because we want offset for seqlen_k
-            n_offset = std::max(int(0), n_idx_left);
-            // Subtract n_offset from seqlen_k for subsequent calculations such as n_block_max
-            seqlen_k -= n_offset;
+            if constexpr (UseLocalKVOffset) {
+                n_offset = std::max(int(0), n_idx_left);
+                seqlen_k -= n_offset;
+            } else {
+                // Keep absolute blocks when the mainloop does not shift KV pointers.
+                n_block_min = std::max(int(0), n_idx_left / kBlockN);
+            }
         }
 
         int n_block_max = cute::ceil_div(seqlen_k, kBlockN);
@@ -46,8 +50,7 @@ struct BlockMN {
             n_block_max = std::min(n_block_max,
                                    cute::ceil_div(m_idx_max + seqlen_k - seqlen_q + window_size_right, kBlockN));
         }
-        // Now, only adjust n_block_min if split
-        int n_block_min = 0;
+        // Partition the selected block range if split.
         // if (threadIdx.x == 128) { printf("Inside, bid.x = %d, bid.y = %d, bid.z = %d, split_idx = %d, n_block_min: %d, n_block_max: %d\n", blockIdx.x, blockIdx.y, blockIdx.z, split_idx, n_block_min, n_block_max); }
         if constexpr (Split) {
             uint32_t num_splits_dynamic_u = reinterpret_cast<uint32_t const&>(split_idx) >> 16; // first 16 bits are for num_splits

--- a/hopper/flash_fwd_kernel_sm80.h
+++ b/hopper/flash_fwd_kernel_sm80.h
@@ -63,12 +63,15 @@ public:
     static constexpr uint32_t MinBlocksPerMultiprocessor = NumThreads == 128 ? 2 : 1;
 
     // Kernel level shared memory storage
-    // We overlap the shared memory for the mainloop and epilogue. However, we only want smem_o to overlap with smem_v + smem_k and not smem_q
-    // and nothing else, so we'll pad in case sizeof(smem_o) > sizeof(smem_v) + sizeof(smem_k).
+    // We overlap shared memory for the mainloop and epilogue. When Q and V are
+    // separate, smem_o must only overlap smem_v + smem_k, so pad if O is larger.
     static constexpr int mainloop_smem_padding_ = int(sizeof(typename CollectiveEpilogue::TensorStorage))
         - int(sizeof(decltype((typename CollectiveMainloop::TensorStorage{}).smem_v)))
         - int(sizeof(decltype((typename CollectiveMainloop::TensorStorage{}).smem_k)));
-    static constexpr int mainloop_smem_padding = mainloop_smem_padding_ < 0 ? 0 : mainloop_smem_padding_;
+    // Q is already consumed before V is loaded when they share storage, so the
+    // epilogue can reuse that union without reserving a separate region for Q.
+    static constexpr int mainloop_smem_padding = CollectiveMainloop::Share_QV_Smem || mainloop_smem_padding_ < 0
+        ? 0 : mainloop_smem_padding_;
     struct SharedStorage {
         struct TensorStorage : cute::aligned_struct<128> {
             union {

--- a/hopper/mainloop_fwd_sm80.hpp
+++ b/hopper/mainloop_fwd_sm80.hpp
@@ -56,7 +56,7 @@ struct CollectiveMainloopFwdSm80 {
     static constexpr int kHeadDim = get<2>(TileShape_MNK{});
 
     using SeqlenInfo_t = flash::SeqlenInfoQKNewK<Varlen, AppendKV>;
-    using BlockMN_t = flash::BlockMN<SeqlenInfo_t, kBlockM, kBlockN, Is_causal, Is_local, PackGQA, Split>;
+    using BlockMN_t = flash::BlockMN<SeqlenInfo_t, kBlockM, kBlockN, Is_causal, Is_local, PackGQA, Split, false /*UseLocalKVOffset*/>;
 
     using MMA_Atom_Arch = std::conditional_t<
         ArchTag::kMinComputeCapability >= 80,

--- a/hopper/test_sm8x_shared_memory.py
+++ b/hopper/test_sm8x_shared_memory.py
@@ -1,0 +1,151 @@
+"""Regression for overlapping Q/V and epilogue shared memory on SM86/SM89."""
+
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "head_dim,local",
+    [(192, False), (256, False), (256, True)],
+    ids=["head192-split-control", "head256-split", "head256-local"],
+)
+@pytest.mark.parametrize(
+    "batch_size,seqlen_q,seqlen_k,num_splits",
+    [(1, 1, 256, 2), (2, 32, 513, 4), (8, 512, 2048, 4)],
+)
+def test_sm8x_shared_memory(
+    batch_size, seqlen_q, seqlen_k, num_splits, head_dim, local, dtype
+):
+    _check_sm8x_shared_memory(
+        batch_size, seqlen_q, seqlen_k, 1 if local else num_splits,
+        head_dim, local, dtype,
+    )
+
+
+def _check_sm8x_shared_memory(
+    batch_size, seqlen_q, seqlen_k, num_splits, head_dim, local, dtype,
+    page_size=None,
+):
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() not in (
+        (8, 6), (8, 9)
+    ):
+        pytest.skip("This shared-memory layout regression targets SM86 and SM89")
+
+    # Read the flags from the installed build, not the current shell environment.
+    # Defer extension imports until after the architecture check so this file can
+    # be collected on machines that do not exercise the affected kernel.
+    from flash_attn_config import CONFIG
+
+    required_features = ["SM8x", "VARLEN", f"HDIM{head_dim}"]
+    if dtype == torch.float16:
+        required_features.append("FP16")
+    if local:
+        required_features.append("LOCAL")
+    if num_splits > 1:
+        required_features.append("SPLIT")
+    if page_size is not None:
+        required_features.append("PAGEDKV")
+    disabled = [
+        feature for feature in required_features
+        if CONFIG["build_flags"][f"FLASHATTENTION_DISABLE_{feature}"]
+    ]
+    if disabled:
+        pytest.skip(f"Required features were not compiled: {', '.join(disabled)}")
+
+    from flash_attn_interface import flash_attn_with_kvcache, get_scheduler_metadata
+    from test_util import attention_ref
+
+    torch.random.manual_seed(12)
+    device = "cuda"
+    nheads, nheads_kv = 4, 2
+    q = torch.randn(batch_size, seqlen_q, nheads, head_dim, device=device, dtype=dtype)
+    k = torch.randn(batch_size, seqlen_k, nheads_kv, head_dim, device=device, dtype=dtype)
+    v = torch.randn_like(k)
+    cache_seqlens = seqlen_k - (
+        torch.arange(batch_size, device=device, dtype=torch.int32) % 3
+    ) * 7
+    key_padding_mask = (
+        torch.arange(seqlen_k, device=device)[None, :] < cache_seqlens[:, None]
+    )
+    window_size = (32, 0) if local else (-1, -1)
+    expected = attention_ref(
+        q, k, v, key_padding_mask=key_padding_mask, window_size=window_size
+    )[0]
+
+    k_cache, v_cache, page_table = k, v, None
+    if page_size is not None:
+        assert seqlen_k % page_size == 0
+        pages_per_sequence = seqlen_k // page_size
+        num_pages = batch_size * pages_per_sequence
+        page_table = torch.arange(
+            num_pages, device=device, dtype=torch.int32
+        ).roll(1).reshape(batch_size, pages_per_sequence)
+        k_cache = torch.empty(
+            num_pages, page_size, nheads_kv, head_dim, device=device, dtype=dtype
+        )
+        v_cache = torch.empty_like(k_cache)
+        # The reference retains logical sequence order; the API must translate
+        # absolute local-attention block coordinates through the shuffled pages.
+        physical_pages = page_table.flatten().long()
+        k_cache[physical_pages] = k.reshape_as(k_cache)
+        v_cache[physical_pages] = v.reshape_as(v_cache)
+
+    scheduler_metadata = get_scheduler_metadata(
+        batch_size, seqlen_q, seqlen_k, nheads, nheads_kv, head_dim,
+        cache_seqlens, dtype, window_size=window_size,
+        num_splits=num_splits, pack_gqa=True, page_size=page_size,
+    )
+    if not local and batch_size == 8:
+        # The prepared scheduler stores num_splits_dynamic and num_m_blocks in
+        # the first two batch vectors (each padded to a multiple of four).
+        # These 8-warp kernels launch one persistent CTA per SM. More work
+        # tiles than SMs forces shared-storage reuse across CTA iterations.
+        batch_rounded = (batch_size + 3) // 4 * 4
+        work_tiles = int((
+            scheduler_metadata[:batch_size]
+            * scheduler_metadata[batch_rounded:batch_rounded + batch_size]
+        ).sum().item()) * nheads_kv
+        sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+        assert work_tiles > sm_count, (work_tiles, sm_count)
+
+    def run():
+        return flash_attn_with_kvcache(
+            q, k_cache, v_cache, cache_seqlens=cache_seqlens, window_size=window_size,
+            num_splits=num_splits, pack_gqa=True,
+            scheduler_metadata=scheduler_metadata, page_table=page_table,
+        )
+
+    out = run()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, expected, rtol=2e-2, atol=2e-2)
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            run()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_out = run()
+    for _ in range(3):
+        # Attention is linear in V. Alternating its sign also detects a replay
+        # that leaves stale output instead of reading the current cache values.
+        v_cache.neg_()
+        expected.neg_()
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(graph_out, expected, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("mode", ["local-split", "local-paged"])
+def test_sm8x_local_block_coordinates(dtype, mode):
+    _check_sm8x_shared_memory(
+        batch_size=2, seqlen_q=32, seqlen_k=512,
+        num_splits=4 if mode == "local-split" else 1,
+        head_dim=256, local=True, dtype=dtype,
+        page_size=256 if mode == "local-paged" else None,
+    )


### PR DESCRIPTION
## Problem

SM86/SM89 FA3 with head dimension 256 can fail at `cudaFuncSetAttribute` when variable-length split attention selects the M128/N48 tile. Q and V share a union, but the epilogue padding calculation counts only V and K, adding an unnecessary 16 KiB reservation. A compiled instance requested 106,752 bytes on an RTX 4090D whose opt-in limit is 101,376 bytes.

Removing that padding also makes the local-attention tile launchable. Its existing SM80 mainloop, however, ignores the `n_offset` returned by `BlockMN`, while the helper shortens the KV range. For Q=1, K=256 and window (32, 0), it loads keys near zero instead of the final window and produces incorrect output.

Addresses the shared-memory launch failure reported in [sgl-project/sglang#38980](https://github.com/sgl-project/sglang/issues/38980). The independently ignored Python `ver` argument is handled by [sglang#39203](https://github.com/sgl-project/sglang/pull/39203).

## Change

- Skip epilogue padding when the mainloop already shares Q/V storage. Preserve the padding needed by separate Q/V layouts.
- Keep absolute local KV block coordinates for the SM80 mainloop. Add a default-enabled `UseLocalKVOffset` template parameter so the SM90 offset path retains its current behavior. The SM80 pointers, masks, paged loads, and new-KV ranges now agree on the same coordinates.
- Add 22 focused pytest cases for SM86/SM89: head192 controls, head256 split/local attention, local+split, and local+paged KV. They exercise eager execution, repeated CUDA Graph replay while changing V, nonidentity page tables, and more work tiles than SMs.

Target branch: `sgl-kernel`, based on `f89bc2306632d1ec5f97b014dded4254f5b4a907`, which is currently pinned by SGLang.

## Validation

Hardware: RTX 4090D (SM89, 114 SMs), CUDA 13.0, PyTorch 2.11.0+cu130, WSL2. The installed `sglang-kernel` 0.4.5 reproduces the original head256 split launch error; head64–192 controls and head256 `num_splits=1` pass.

I compiled focused native instances directly from the exact three changed production headers, together with the production scheduler and combine kernels, using the runner's existing FlashInfer CUTLASS headers. The final build used `-O3 --use_fast_math -fno-strict-aliasing` and **SM86 cubins executed on SM89**. Source and binary hashes were recorded.

- Unmodified source: head192 controls pass; head256 split fails at the same shared-memory attribute call.
- Padding-only change: split cases pass, and the local-coordinate problem above becomes observable.
- Final change: **22/22 native CUDA cases pass**, with a PyTorch math-attention reference, eager execution, and three graph replays that alternate V's sign. This includes fp16/bf16, varying cache lengths, local+split, and shuffled paged KV.
- Largest persistent case: 128 actual work tiles on 114 SMs, exercising reuse across scheduler iterations.
- Compiled head256 split shared memory: **106,752 -> 90,496 bytes**, below the 101,376-byte device limit.
- Maximum absolute reference difference across the final matrix: 0.0078125 (bf16).
- The added pytest file passes syntax/static checks; `git diff --check` passes.

A complete `flash_attn_3_cuda` wheel was not rebuilt, so the newly added public-API pytest file has not been run as a full extension test here. The native matrix above directly executes the changed production kernels. No Hopper runtime or performance claim is made.
